### PR TITLE
Fix parsing of ipv6 endpoints

### DIFF
--- a/snmpsim/endpoints.py
+++ b/snmpsim/endpoints.py
@@ -77,7 +77,7 @@ def parse_endpoint(arg, ipv6=False):
 
     try:
         if ':' in address:
-            address, port = address.split(':', 1)
+            address, port = address.rsplit(':', 1)
             port = int(port)
 
         else:


### PR DESCRIPTION
Ipv6 address contains colons,
so just splitting once does not work.
Rsplit fixes the issue