### PR TITLE
Always print out listening message

### DIFF
--- a/snmpsim/commands/pcap2rec.py
+++ b/snmpsim/commands/pcap2rec.py
@@ -334,7 +334,7 @@ def main():
 
     if args.listen_interface:
         if not args.quiet:
-            log.info(
+            log.msg(
                 'Listening on interface %s in %spromiscuous '
                 'mode' % (args.listen_interface,
                           '' if args.promiscuous_mode else 'non-'))
@@ -515,7 +515,7 @@ def main():
 
     try:
         if args.listen_interface:
-            log.info(
+            log.msg(
                 'Listening on interface "%s", kill me when you '
                 'are done.' % args.listen_interface)
 

--- a/snmpsim/commands/responder.py
+++ b/snmpsim/commands/responder.py
@@ -760,7 +760,7 @@ configured automatically based on simulation data file paths relative to
                     config.addSocketTransport(
                         snmp_engine, transport_domain, agent_udpv4_endpoint[0])
 
-                    log.info(
+                    log.msg(
                         'Listening at UDP/IPv4 endpoint %s, transport ID '
                         '%s' % (agent_udpv4_endpoint[1],
                                 '.'.join([str(handler) for handler in transport_domain])))
@@ -776,7 +776,7 @@ configured automatically based on simulation data file paths relative to
                         snmp_engine,
                         transport_domain, agent_udpv6_endpoint[0])
 
-                    log.info(
+                    log.msg(
                         'Listening at UDP/IPv6 endpoint %s, transport ID '
                         '%s' % (agent_udpv6_endpoint[1],
                                 '.'.join([str(handler) for handler in transport_domain])))

--- a/snmpsim/commands/responder_lite.py
+++ b/snmpsim/commands/responder_lite.py
@@ -455,7 +455,7 @@ def main():
         transport_dispatcher.registerTransport(
             transport_domain, agent_udpv4_endpoint[0])
 
-        log.info('Listening at UDP/IPv4 endpoint %s, transport ID '
+        log.msg('Listening at UDP/IPv4 endpoint %s, transport ID '
                  '%s' % (agent_udpv4_endpoint[1],
                          '.'.join([str(handler) for handler in transport_domain])))
 
@@ -471,7 +471,7 @@ def main():
         transport_dispatcher.registerTransport(
             transport_domain, agent_udpv6_endpoint[0])
 
-        log.info('Listening at UDP/IPv6 endpoint %s, transport ID '
+        log.msg('Listening at UDP/IPv6 endpoint %s, transport ID '
                  '%s' % (agent_udpv6_endpoint[1],
                          '.'.join([str(handler) for handler in transport_domain])))
 


### PR DESCRIPTION
This is helpful for waiting until snmpsim is ready to respond to requests
Previously, you would have to set the log level to at least info which is very noisy and can add latency to requests.
This will still print nothing when --quiet or --logging-method=null is set