### PR TITLE
Fix variation-module-options parsing in numeric.py

### DIFF
--- a/snmpsim/variation/numeric.py
+++ b/snmpsim/variation/numeric.py
@@ -44,16 +44,16 @@ def init(**context):
 
         if context['options']:
             for x in split(context['options'], ','):
-                for k, v in split(x, ':'):
-                    if k == 'addon':
-                        if k in moduleContext['settings']:
-                            moduleContext['settings'][k].append(v)
-
-                        else:
-                            moduleContext['settings'][k] = [v]
+                k, v = split(x, ':')
+                if k == 'addon':
+                    if k in moduleContext['settings']:
+                        moduleContext['settings'][k].append(v)
 
                     else:
-                        moduleContext['settings'][k] = v
+                        moduleContext['settings'][k] = [v]
+
+                else:
+                    moduleContext['settings'][k] = v
 
                 if 'iterations' in moduleContext['settings']:
                     moduleContext['settings']['iterations'] = int(


### PR DESCRIPTION
* removes unnecessary 'for' loop during numeric module options processing
* the aforementioned loop led to an exception before this fix: 'ValueError: too many values to unpack (expected 2)' Exception was thrown since the utils.split() method returns a flat  list and not a dict[list] or the like