### PR TITLE
Fixed parse escaped value with space at end of string

### DIFF
--- a/snmpsim/grammar/snmprec.py
+++ b/snmpsim/grammar/snmprec.py
@@ -46,14 +46,14 @@ class SnmprecGrammar(AbstractGrammar):
 
     def parse(self, line):
         try:
-            oid, tag, value = line.decode("iso-8859-1").strip().split("|", 2)
+            oid, tag, value = line.decode("iso-8859-1").split("|", 2)
 
         except Exception as exc:
             raise error.SnmpsimError(f"broken record <{line}>: {exc}")
 
         else:
             if oid and tag:
-                return oid, tag, value
+                return oid.strip(), tag.strip(), value.strip("\r\n\t")
 
             raise error.SnmpsimError("broken record <%s>" % line)
 

--- a/tests/test_snmprec_grammar.py
+++ b/tests/test_snmprec_grammar.py
@@ -1,0 +1,12 @@
+from snmpsim.record.snmprec import SnmprecRecord
+
+
+def test_escaped_value_preserves_trailing_space():
+    record = SnmprecRecord()
+
+    oid, value = record.evaluate(
+        b"1.3.6.1.2.1.3.1.1.3.3.1.85.209.202.32|64e|U\\xd1\\xca \n"
+    )
+
+    assert oid.prettyPrint() == "1.3.6.1.2.1.3.1.1.3.3.1.85.209.202.32"
+    assert list(value) == [85, 209, 202, 32]


### PR DESCRIPTION
## Summary

Fixed parsing of escaped `.snmprec` values that end with a significant space character. The parser used to strip the whole record before splitting fields, so a trailing space in the value field was lost before escaped value evaluation.

## Problem

For some escaped values, snmpsim fails with an error like:

```text
ERROR data error at loadmaster.snmprec controller for 1.3.6.1.2.1.3.1.1.3.3.1.85.209.202.31: value evaluation error for tag `64`, value [85, 209, 202]: Bad IP address syntax
```

For example, this request returns an IP address whose last byte can be encoded as a trailing space in the escaped `.snmprec` value:

```console
$ snmpwalk -v2c -c community -Pu -M ../rfc:../net-snmp:. -m ALL hostname .1.3.6.1.2.1.3.1.1.3.3.1
RFC1213-MIB::atNetAddress.3.1.85.209.202.31 = Network Address: 55:D1:CA:1F
RFC1213-MIB::atNetAddress.3.1.85.209.202.31 = No more variables left in this MIB View (It is past the end of the MIB tree)
```

Relevant part of `loadmaster.snmprec`:

```text
1.3.6.1.2.1.3.1.1.3.3.1.85.209.202.31|64e|U\xd1\xca\x1f
1.3.6.1.2.1.3.1.1.3.3.1.85.209.202.32|64e|U\xd1\xca 
```

In the last line, the space at the end of the value is significant and should be converted to number 32. This change trims only OID/tag whitespace and record terminators from the value, preserving the trailing value space.

## Tests

```console
.venv/bin/python -B -m pytest tests
```

Result: `2 passed, 5 skipped`.

Ported from https://github.com/stupalov/inexio-snmpsim/commit/a1275f99d8f7f9426300d138541290f0aaade6c6